### PR TITLE
Delete travis dep

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,6 @@ jdk:
 
 stages:
   - name: build
-  - name: test
-    if: type = pull_request
   - name: deploy
     if: branch = master AND type != pull_request
 
@@ -16,10 +14,7 @@ jobs:
   include:
     - stage: build
       script:
-        - ./gradlew clean build
-    - stage: test
-      script:
-        - ./gradlew test
+        - ./gradlew clean build test
     - stage: deploy
       script:
         - ./deploy-scripts/deploy.sh

--- a/README.md
+++ b/README.md
@@ -8,45 +8,47 @@
 **Hood** has two tasks to compare benchmarks:
  - `compareBenchmarks`: Compare two benchmarks and print the result.
  - `compareBenchmarksCI`: Compare two benchmarks and upload a `Github` status for a `Pull Request`.
- 
- Both tasks have common parameters:
-  - **previousBenchmarkPath**: File with previous or master benchmark location. By default: `master.csv`.
-  - **currentBenchmarkPath**: List of files with current or pull request benchmark location. By default is an `empty list`.
-  - **keyColumnName**: Column name to distinct each benchmark on the comparison. By default: `Benchmark`.
-  - **compareColumnName**: Column name of the column to compare (the values must to be a `Double`). By default: `Score`.
-  - **thresholdColumnName**: Column name to get the threshold per benchmark. By default: `Score Error (99.9%)`.
-  - **generalThreshold**: Common threshold to all benchmarks overriding the value coming from `thresholdColumnName`. Optional.
-  - **benchmarkThreshold**: `Map` with a custom threshold per benchmark key overriding the value coming from `thresholdColumnName` or `generalThreshold`. Optional.
-  - **include**: Regular expression to include only the benchmarks with a matching key. Optional.
-  - **exclude**: Regular expression to exclude the benchmarks using its key. Optional.
-  
- The `include/exclude` feature and `benchmarkThreshold` param use the cleaned key from benchmarks. 
- This means the key for `hood.comparing` will be `Comparing` with the capitalization.
- 
- The `compareBenchmarksCI` task also needs some extra parameters:
-  - **token**: The `Github` access token.
-  - **slug**: The repository slug with the format `owner/repository`. The environment variable `TRAVIS_PULL_REQUEST` on Travis CI.
-  - **pullRequestSha**: The sha for the Pull Request. The environment variable `TRAVIS_REPO_SLUG` on Travis CI.
-  - **pullRequestNumber**: The number of the Pull Request. The environment variable `TRAVIS_PULL_REQUEST_SHA` on Travis CI.
 
- ***Note***: Currently **Hood** only supports `CSV` and `JSON` based benchmarks with cross comparison available.
+Both tasks have common parameters:
+ - **previousBenchmarkPath**: File with previous or master benchmark location. By default: `master.csv`.
+ - **currentBenchmarkPath**: List of files with current or pull request benchmark location. By default is an `empty list`.
+ - **keyColumnName**: Column name to distinct each benchmark on the comparison. By default: `Benchmark`.
+ - **compareColumnName**: Column name of the column to compare (the values must to be a `Double`). By default: `Score`.
+ - **thresholdColumnName**: Column name to get the threshold per benchmark. By default: `Score Error (99.9%)`.
+ - **generalThreshold**: Common threshold to all benchmarks overriding the value coming from `thresholdColumnName`. Optional.
+ - **benchmarkThreshold**: `Map` with a custom threshold per benchmark key overriding the value coming from `thresholdColumnName` or `generalThreshold`. Optional.
+ - **include**: Regular expression to include only the benchmarks with a matching key. Optional.
+ - **exclude**: Regular expression to exclude the benchmarks using its key. Optional.
  
- ### Send output to a file
- 
- Both task can send the result to a file, just need to fulfill the following parameters:
-  - **outputToFile**: If send the output to a file. By default: `false`.
-  - **outputPath**: The path to the output file. By default: `./hood/comparison`.
-  - **outputFormat**: The output file format, we support two formats `MD` and `JSON`. By default: `MD`.
- 
- ***Note***: To print a `JSON` output file, all the benchmarks must to be in `JSON` format. `CSV` benchmarks will be ignored.
- 
- ## Upload benchmarks
- 
- **Hood** allow you to upload automatically the benchmarks 
- you want to maintain updated in your code thought commits during the CI.
- 
- The task `uploadBenchmark` has the following parameters:
-  - **benchmarkFiles**: The list of benchmark files you want to upload. By default is an `empty list`.
-  - **uploadDirectory**: The path for the folder where you want to keep them, from project root directory. By default: `benchmarks`.
-  - **commitMessage**: The message for the task commit uploading the benchmark. By default: `Upload benchmark`.
-  - **token**: the `Github` access token.
+The `include/exclude` feature and `benchmarkThreshold` param use the cleaned key from benchmarks. 
+This means the key for `hood.comparing` will be `Comparing` with the capitalization.
+
+The `compareBenchmarksCI` task also needs some extra parameters:
+ - **token**: The `Github` access token.
+ - **slug**: The repository slug with the format `owner/repository`. The environment variable `TRAVIS_PULL_REQUEST` on Travis CI.
+ - **pullRequestSha**: The sha for the Pull Request. The environment variable `TRAVIS_REPO_SLUG` on Travis CI.
+ - **pullRequestNumber**: The number of the Pull Request. The environment variable `TRAVIS_PULL_REQUEST_SHA` on Travis CI.
+
+***Note***: Currently **Hood** only supports `CSV` and `JSON` based benchmarks with cross comparison available.
+
+### Send output to a file
+
+Both task can send the result to a file, just need to fulfill the following parameters:
+ - **outputToFile**: If send the output to a file. By default: `false`.
+ - **outputPath**: The path to the output file. By default: `./hood/comparison`.
+ - **outputFormat**: The output file format, we support two formats `MD` and `JSON`. By default: `MD`.
+
+***Note***: To print a `JSON` output file, all the benchmarks must to be in `JSON` format. `CSV` benchmarks will be ignored.
+
+## Upload benchmarks
+
+**Hood** allow you to upload automatically the benchmarks 
+you want to maintain updated in your code thought commits during the CI.
+
+The task `uploadBenchmark` has the following parameters:
+ - **benchmarkFiles**: The list of benchmark files you want to upload. By default is an `empty list`.
+ - **uploadDirectory**: The path for the folder where you want to keep them, from project root directory. By default: `benchmarks`.
+ - **commitMessage**: The message for the task commit uploading the benchmark. By default: `Upload benchmark`.
+ - **token**: the `Github` access token.
+ - **slug**: The repository slug with the format `owner/repository`. The environment variable `TRAVIS_PULL_REQUEST` on Travis CI.
+ - **branch**: The branch where you want to upload those benchmarks. By default: `master`.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ This means the key for `hood.comparing` will be `Comparing` with the capitalizat
 
 The `compareBenchmarksCI` task also needs some extra parameters:
  - **token**: The `Github` access token.
- - **slug**: The repository slug with the format `owner/repository`. The environment variable `TRAVIS_REPO_SLUG` on Travis CI.
+ - **owner**: The repository owner.
+ - **repository**: The repository name.
  - **pullRequestSha**: The sha for the Pull Request. The environment variable `TRAVIS_PULL_REQUEST_SHA` on Travis CI.
  - **pullRequestNumber**: The number of the Pull Request. The environment variable `TRAVIS_PULL_REQUEST` on Travis CI.
 
@@ -50,5 +51,6 @@ The task `uploadBenchmark` has the following parameters:
  - **uploadDirectory**: The path for the folder where you want to keep them, from project root directory. By default: `benchmarks`.
  - **commitMessage**: The message for the task commit uploading the benchmark. By default: `Upload benchmark`.
  - **token**: the `Github` access token.
- - **slug**: The repository slug with the format `owner/repository`. The environment variable `TRAVIS_REPO_SLUG` on Travis CI.
+ - **owner**: The repository owner.
+ - **repository**: The repository name.
  - **branch**: The branch where you want to upload those benchmarks. By default: `master`.

--- a/README.md
+++ b/README.md
@@ -23,8 +23,11 @@
  The `include/exclude` feature and `benchmarkThreshold` param use the cleaned key from benchmarks. 
  This means the key for `hood.comparing` will be `Comparing` with the capitalization.
  
- The `compareBenchmarksCI` task also needs an extra parameter, **token**, the `Github` access token. 
- At this moment, only `travis-ci` is supported.
+ The `compareBenchmarksCI` task also needs some extra parameters:
+  - **token**: The `Github` access token.
+  - **slug**: The repository slug with the format `owner/repository`. The environment variable `TRAVIS_PULL_REQUEST` on Travis CI.
+  - **pullRequestSha**: The sha for the Pull Request. The environment variable `TRAVIS_REPO_SLUG` on Travis CI.
+  - **pullRequestNumber**: The number of the Pull Request. The environment variable `TRAVIS_PULL_REQUEST_SHA` on Travis CI.
 
  ***Note***: Currently **Hood** only supports `CSV` and `JSON` based benchmarks with cross comparison available.
  
@@ -39,11 +42,11 @@
  
  ## Upload benchmarks
  
- **Hood** allow you to upload automatically the benchmark 
+ **Hood** allow you to upload automatically the benchmarks 
  you want to maintain updated in your code thought commits during the CI.
  
  The task `uploadBenchmark` has the following parameters:
-  - **benchmarkFile**: The benchmark file you want to upload. By default: `benchmarks/master_benchmark.csv.`
-  - **benchmarkDestinationFromProjectRoot**: The path for the file where you want to keep it, from project root directory. By default: `benchmarks/master_benchmark.csv.`
+  - **benchmarkFiles**: The list of benchmark files you want to upload. By default is an `empty list`.
+  - **uploadDirectory**: The path for the folder where you want to keep them, from project root directory. By default: `benchmarks`.
   - **commitMessage**: The message for the task commit uploading the benchmark. By default: `Upload benchmark`.
   - **token**: the `Github` access token.

--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ This means the key for `hood.comparing` will be `Comparing` with the capitalizat
 
 The `compareBenchmarksCI` task also needs some extra parameters:
  - **token**: The `Github` access token.
- - **slug**: The repository slug with the format `owner/repository`. The environment variable `TRAVIS_PULL_REQUEST` on Travis CI.
- - **pullRequestSha**: The sha for the Pull Request. The environment variable `TRAVIS_REPO_SLUG` on Travis CI.
- - **pullRequestNumber**: The number of the Pull Request. The environment variable `TRAVIS_PULL_REQUEST_SHA` on Travis CI.
+ - **slug**: The repository slug with the format `owner/repository`. The environment variable `TRAVIS_REPO_SLUG` on Travis CI.
+ - **pullRequestSha**: The sha for the Pull Request. The environment variable `TRAVIS_PULL_REQUEST_SHA` on Travis CI.
+ - **pullRequestNumber**: The number of the Pull Request. The environment variable `TRAVIS_PULL_REQUEST` on Travis CI.
 
 ***Note***: Currently **Hood** only supports `CSV` and `JSON` based benchmarks with cross comparison available.
 
@@ -50,5 +50,5 @@ The task `uploadBenchmark` has the following parameters:
  - **uploadDirectory**: The path for the folder where you want to keep them, from project root directory. By default: `benchmarks`.
  - **commitMessage**: The message for the task commit uploading the benchmark. By default: `Upload benchmark`.
  - **token**: the `Github` access token.
- - **slug**: The repository slug with the format `owner/repository`. The environment variable `TRAVIS_PULL_REQUEST` on Travis CI.
+ - **slug**: The repository slug with the format `owner/repository`. The environment variable `TRAVIS_REPO_SLUG` on Travis CI.
  - **branch**: The branch where you want to upload those benchmarks. By default: `master`.

--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ This means the key for `hood.comparing` will be `Comparing` with the capitalizat
 
 The `compareBenchmarksCI` task also needs some extra parameters:
  - **token**: The `Github` access token.
- - **owner**: The repository owner.
- - **repository**: The repository name.
+ - **repositoryOwner**: The repository owner.
+ - **repositoryName**: The repository name.
  - **pullRequestSha**: The sha for the Pull Request. The environment variable `TRAVIS_PULL_REQUEST_SHA` on Travis CI.
  - **pullRequestNumber**: The number of the Pull Request. The environment variable `TRAVIS_PULL_REQUEST` on Travis CI.
 
@@ -51,6 +51,6 @@ The task `uploadBenchmark` has the following parameters:
  - **uploadDirectory**: The path for the folder where you want to keep them, from project root directory. By default: `benchmarks`.
  - **commitMessage**: The message for the task commit uploading the benchmark. By default: `Upload benchmark`.
  - **token**: the `Github` access token.
- - **owner**: The repository owner.
- - **repository**: The repository name.
+ - **repositoryOwner**: The repository owner.
+ - **repositoryName**: The repository name.
  - **branch**: The branch where you want to upload those benchmarks. By default: `master`.

--- a/build.gradle
+++ b/build.gradle
@@ -82,7 +82,7 @@ bintray {
   publish = true
   user = findPropertyOrEnv("BINTRAY_USER") ?: "no.bintray.user"
   key = findPropertyOrEnv("BINTRAY_API_KEY") ?: "no.bintray.api.key"
-  publications = ["MyPublication"]
+  publications = ["HoodPublication"]
   configurations = ["archives"]
   pkg {
     repo = "hood"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 # Package definitions
 GROUP=com.47deg
-VERSION_NAME=0.5.0
+VERSION_NAME=0.5.2-SNAPSHOT
 # Gradle options
 org.gradle.warning.mode=all
 #Settings

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 # Package definitions
 GROUP=com.47deg
-VERSION_NAME=0.5.2-SNAPSHOT
+VERSION_NAME=0.6.0
 # Gradle options
 org.gradle.warning.mode=all
 #Settings

--- a/gradle/gradle-mvn-push.gradle
+++ b/gradle/gradle-mvn-push.gradle
@@ -28,7 +28,7 @@ task javadocJar(type: Jar, dependsOn: javadoc) {
 
 publishing {
   publications {
-    MyPublication(MavenPublication) {
+    HoodPublication(MavenPublication) {
 
       artifactId = POM_ARTIFACT_ID
       groupId = group

--- a/src/main/kotlin/com/fortysevendeg/hood/tasks/CompareBenchmarkCI.kt
+++ b/src/main/kotlin/com/fortysevendeg/hood/tasks/CompareBenchmarkCI.kt
@@ -69,9 +69,9 @@ open class CompareBenchmarkCI : DefaultTask() {
   @get:Input
   var token: String? = project.objects.property(String::class.java).orNull
   @get:Input
-  var owner: String? = project.objects.property(String::class.java).orNull
+  var repositoryOwner: String? = project.objects.property(String::class.java).orNull
   @get:Input
-  var repository: String? = project.objects.property(String::class.java).orNull
+  var repositoryName: String? = project.objects.property(String::class.java).orNull
   @get:Input
   var pullRequestSha: String? = project.objects.property(String::class.java).orNull
   @get:Input
@@ -140,15 +140,15 @@ open class CompareBenchmarkCI : DefaultTask() {
   @TaskAction
   fun compareBenchmarkCI() =
     Option.applicative().map(
-      owner.toOption(),
-      repository.toOption(),
+      repositoryOwner.toOption(),
+      repositoryName.toOption(),
       pullRequestSha.toOption(),
       pullRequestNumber.toOption()
-    ) { (projectOwner, projectRepo, sha, number) ->
+    ) { (owner, name, sha, number) ->
       fx {
         val (token: String) = token.toOption().getOrRaiseError { GradleException("Error getting Github token") }
 
-        val info = GhInfo(projectOwner, projectRepo, token)
+        val info = GhInfo(owner, name, token)
 
         !compareCI(info, sha, number)
       }.fix()
@@ -156,7 +156,7 @@ open class CompareBenchmarkCI : DefaultTask() {
       .getOrElse {
         IO.raiseError(
           GradleException(
-            "Missing one of the following parameters: 'owner', 'repository', 'pullRequestSha', 'pullRequestNumber'"
+            "Missing one of the following parameters: 'repositoryOwner', 'repositoryName', 'pullRequestSha', 'pullRequestNumber'"
           )
         )
       }

--- a/src/main/kotlin/com/fortysevendeg/hood/tasks/UploadBenchmark.kt
+++ b/src/main/kotlin/com/fortysevendeg/hood/tasks/UploadBenchmark.kt
@@ -1,7 +1,9 @@
 package com.fortysevendeg.hood.tasks
 
 import arrow.core.toOption
+import arrow.data.extensions.list.foldable.traverse_
 import arrow.effects.IO
+import arrow.effects.extensions.io.applicative.applicative
 import arrow.effects.extensions.io.fx.fx
 import arrow.effects.fix
 import com.fortysevendeg.hood.OutputFile
@@ -12,23 +14,49 @@ import com.fortysevendeg.hood.github.GithubCommitIntegration
 import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
 import org.gradle.api.tasks.Input
-import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.TaskAction
 import java.io.File
 
 open class UploadBenchmark : DefaultTask() {
 
-  @get:InputFile
-  var benchmarkFile: File =
-    project.objects.fileProperty().asFile.getOrElse(File("benchmarks/master_benchmark.csv"))
+  @get:InputFiles
+  var benchmarkFiles: List<File> =
+    project.objects.listProperty(File::class.java).getOrElse(emptyList())
   @get:Input
-  var benchmarkDestinationFromProjectRoot: String =
-    project.objects.property(String::class.java).getOrElse("benchmarks/master_benchmark.csv")
+  var uploadDirectory: String =
+    project.objects.property(String::class.java).getOrElse("benchmarks")
   @get:Input
   var commitMessage: String =
     project.objects.property(String::class.java).getOrElse("Upload benchmark")
   @get:Input
   var token: String? = project.objects.property(String::class.java).orNull
+
+  private fun upload(info: GhInfo, branch: String, benchmarkFile: File): IO<Unit> = fx {
+
+    val destination = uploadDirectory + benchmarkFile.name
+    val fileSha = !GithubCommitIntegration.getFileSha(info, branch, destination)
+
+    val content = !OutputFile.readFileToBase64(benchmarkFile)
+
+    fileSha.fold({
+      val createCommit = GhCreateCommit(commitMessage, content, branch)
+      !GithubCommitIntegration.createFileCommit(
+        info,
+        destination,
+        createCommit
+      )
+    }, {
+      val updateCommit =
+        GhUpdateCommit(commitMessage, content, it.sha, branch)
+      !GithubCommitIntegration.updateFileCommit(
+        info,
+        destination,
+        updateCommit
+      )
+    })
+
+  }
 
   @TaskAction
   fun uploadBenchmark(): Unit = fx {
@@ -39,33 +67,15 @@ open class UploadBenchmark : DefaultTask() {
     val owner: String = slug.first()
     val repo: String = slug.last()
 
-    val (token: String) =
+    val (ghToken: String) =
       token.toOption()
         .fold({ raiseError<String>(GradleException("Error getting Github token")) }) { IO { it } }
 
-    val info = GhInfo(owner, repo, token)
+    val info = GhInfo(owner, repo, ghToken)
 
-    val fileSha =
-      !GithubCommitIntegration.getFileSha(info, branch, benchmarkDestinationFromProjectRoot)
-
-    val content = !OutputFile.readFileToBase64(benchmarkFile)
-
-    fileSha.fold({
-      val createCommit = GhCreateCommit(commitMessage, content, branch)
-      !GithubCommitIntegration.createFileCommit(
-        info,
-        benchmarkDestinationFromProjectRoot,
-        createCommit
-      )
-    }, {
-      val updateCommit =
-        GhUpdateCommit(commitMessage, content, it.sha, branch)
-      !GithubCommitIntegration.updateFileCommit(
-        info,
-        benchmarkDestinationFromProjectRoot,
-        updateCommit
-      )
-    })
+    !benchmarkFiles.traverse_(IO.applicative()) {
+      upload(info, branch, it)
+    }
 
   }.fix().unsafeRunSync()
 

--- a/src/main/kotlin/com/fortysevendeg/hood/tasks/UploadBenchmark.kt
+++ b/src/main/kotlin/com/fortysevendeg/hood/tasks/UploadBenchmark.kt
@@ -34,9 +34,9 @@ open class UploadBenchmark : DefaultTask() {
   @get:Input
   var token: String? = project.objects.property(String::class.java).orNull
   @get:Input
-  var owner: String? = project.objects.property(String::class.java).orNull
+  var repositoryOwner: String? = project.objects.property(String::class.java).orNull
   @get:Input
-  var repository: String? = project.objects.property(String::class.java).orNull
+  var repositoryName: String? = project.objects.property(String::class.java).orNull
   @get:Input
   var branch: String =
     project.objects.property(String::class.java).getOrElse("master")
@@ -70,16 +70,16 @@ open class UploadBenchmark : DefaultTask() {
 
   @TaskAction
   fun uploadBenchmark(): Unit =
-    owner.toOption().map2(repository.toOption()) { (projectOwner, projectRepo) ->
+    repositoryOwner.toOption().map2(repositoryName.toOption()) { (owner, repo) ->
       fx {
         val (ghToken: String) = token.toOption().getOrRaiseError { GradleException("Error getting Github token") }
 
-        val info = GhInfo(projectOwner, projectRepo, ghToken)
+        val info = GhInfo(owner, repo, ghToken)
 
         !benchmarkFiles.traverse_(IO.applicative()) { upload(info, branch, it) }
       }.fix()
     }.getOrElse {
-      IO.raiseError(GradleException("Missing one of the following parameters: 'owner', 'repository'"))
+      IO.raiseError(GradleException("Missing one of the following parameters: 'repositoryOwner', 'repositoryName'"))
     }.unsafeRunSync()
 
 }

--- a/src/main/kotlin/com/fortysevendeg/hood/tasks/UploadBenchmark.kt
+++ b/src/main/kotlin/com/fortysevendeg/hood/tasks/UploadBenchmark.kt
@@ -39,7 +39,8 @@ open class UploadBenchmark : DefaultTask() {
 
   private fun upload(info: GhInfo, branch: String, benchmarkFile: File): IO<Unit> = fx {
 
-    val destination = uploadDirectory + benchmarkFile.name
+    val parent = if (uploadDirectory.endsWith('/')) uploadDirectory else "$uploadDirectory/"
+    val destination = parent + benchmarkFile.name
     val fileSha = !GithubCommitIntegration.getFileSha(info, branch, destination)
 
     val content = !OutputFile.readFileToBase64(benchmarkFile)


### PR DESCRIPTION
This pr deletes the Travis dependency from CI task moving the info required to parameters.
Also allows upload multiple benchmarks using the same task.

Release 0.6.0