### PR TITLE
Fail on bad performance

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,9 +1,9 @@
 buildscript {
   ext {
-    kotlinVersion = "1.3.31"
+    kotlinVersion = "1.3.40"
     arrowVersion = "0.9.0"
-    http4kVersion = "3.113.0"
-    kotlintestVersion = "3.3.0"
+    http4kVersion = "3.160.1"
+    kotlintestVersion = "3.3.3"
     bintrayVersion = "1.8.4"
     csvVersion = "1.5"
   }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 # Package definitions
 GROUP=com.47deg
-VERSION_NAME=0.6.0
+VERSION_NAME=0.6.1
 # Gradle options
 org.gradle.warning.mode=all
 #Settings

--- a/src/main/kotlin/com/fortysevendeg/hood/BenchmarkFilter.kt
+++ b/src/main/kotlin/com/fortysevendeg/hood/BenchmarkFilter.kt
@@ -2,9 +2,7 @@ package com.fortysevendeg.hood
 
 import arrow.core.Either
 import arrow.core.Option
-import arrow.core.left
-import arrow.core.right
-import arrow.data.extensions.list.foldable.nonEmpty
+import arrow.data.NonEmptyList
 import com.fortysevendeg.hood.models.*
 
 private fun List<Benchmark>.filterUsingRegex(
@@ -27,9 +25,9 @@ fun List<Benchmark>.filterBenchmarkIE(
 fun List<BenchmarkComparison>.getWrongResults(): List<BenchmarkComparison> =
   this.filter { it.result::class == BenchmarkResult.FAILED::class }
 
-fun List<BenchmarkComparison>.handleFailures(): Either<BenchmarkComparisonError, List<BenchmarkComparison>> {
-  val failures = this.getWrongResults()
-  return if (failures.nonEmpty())
-    BenchmarkComparisonError(BadPerformanceBenchmarkError(failures)).left()
-  else this.right()
-}
+fun List<BenchmarkComparison>.handleFailures(): Either<BenchmarkComparisonError, List<BenchmarkComparison>> =
+  NonEmptyList.fromList(getWrongResults()).toEither { this }.map {
+    BenchmarkComparisonError(
+      BadPerformanceBenchmarkError(it.all)
+    )
+  }.swap()

--- a/src/main/kotlin/com/fortysevendeg/hood/BenchmarkFilter.kt
+++ b/src/main/kotlin/com/fortysevendeg/hood/BenchmarkFilter.kt
@@ -1,7 +1,11 @@
 package com.fortysevendeg.hood
 
+import arrow.core.Either
 import arrow.core.Option
-import com.fortysevendeg.hood.models.Benchmark
+import arrow.core.left
+import arrow.core.right
+import arrow.data.extensions.list.foldable.nonEmpty
+import com.fortysevendeg.hood.models.*
 
 private fun List<Benchmark>.filterUsingRegex(
   maybeRegex: Option<Regex>,
@@ -19,3 +23,13 @@ fun List<Benchmark>.filterBenchmarkIE(
   includeRegex: Option<Regex>,
   excludeRegex: Option<Regex>
 ): List<Benchmark> = filterBenchmark(includeRegex).filterBenchmarkNot(excludeRegex)
+
+fun List<BenchmarkComparison>.getWrongResults(): List<BenchmarkComparison> =
+  this.filter { it.result::class == BenchmarkResult.FAILED::class }
+
+fun List<BenchmarkComparison>.handleFailures(): Either<BenchmarkComparisonError, List<BenchmarkComparison>> {
+  val failures = this.getWrongResults()
+  return if (failures.nonEmpty())
+    BenchmarkComparisonError(BadPerformanceBenchmarkError(failures)).left()
+  else this.right()
+}

--- a/src/main/kotlin/com/fortysevendeg/hood/BenchmarkFilter.kt
+++ b/src/main/kotlin/com/fortysevendeg/hood/BenchmarkFilter.kt
@@ -27,7 +27,5 @@ fun List<BenchmarkComparison>.getWrongResults(): List<BenchmarkComparison> =
 
 fun List<BenchmarkComparison>.handleFailures(): Either<BenchmarkComparisonError, List<BenchmarkComparison>> =
   NonEmptyList.fromList(getWrongResults()).toEither { this }.map {
-    BenchmarkComparisonError(
-      BadPerformanceBenchmarkError(it.all)
-    )
+    BenchmarkComparisonError(BadPerformanceBenchmarkError(it.all))
   }.swap()

--- a/src/main/kotlin/com/fortysevendeg/hood/Comparator.kt
+++ b/src/main/kotlin/com/fortysevendeg/hood/Comparator.kt
@@ -6,9 +6,7 @@ import arrow.data.extensions.list.foldable.forAll
 import arrow.data.extensions.list.semigroup.plus
 import arrow.data.foldLeft
 import arrow.effects.IO
-import arrow.effects.extensions.io.applicativeError.handleError
 import arrow.effects.extensions.io.fx.fx
-import arrow.effects.fix
 import com.fortysevendeg.hood.models.*
 import com.fortysevendeg.hood.reader.CsvBenchmarkReader
 import com.fortysevendeg.hood.reader.JsonBenchmarkReader
@@ -159,7 +157,8 @@ object Comparator {
     if (isConsistent)
       previousBenchmarksAfterFilter.second.flatMap { prev ->
         val threshold = selectThreshold(prev, maybeGeneralThreshold, maybeBenchmarkThreshold)
-        val previousModified = prev.withName(previousBenchmarksAfterFilter.first).withThreshold(threshold)
+        val previousModified =
+          prev.withName(previousBenchmarksAfterFilter.first).withThreshold(threshold)
 
         getCompareResults(currentBenchmarksAfterFilter, prev, threshold).map {
           buildBenchmarkComparison(prev.getKey(), previousModified, it)

--- a/src/main/kotlin/com/fortysevendeg/hood/Comparator.kt
+++ b/src/main/kotlin/com/fortysevendeg/hood/Comparator.kt
@@ -6,6 +6,8 @@ import arrow.data.extensions.list.foldable.forAll
 import arrow.data.extensions.list.semigroup.plus
 import arrow.data.foldLeft
 import arrow.effects.IO
+import arrow.effects.fix
+import arrow.effects.extensions.io.applicativeError.handleError
 import arrow.effects.extensions.io.fx.fx
 import com.fortysevendeg.hood.models.*
 import com.fortysevendeg.hood.reader.CsvBenchmarkReader

--- a/src/main/kotlin/com/fortysevendeg/hood/HoodComparison.kt
+++ b/src/main/kotlin/com/fortysevendeg/hood/HoodComparison.kt
@@ -1,0 +1,132 @@
+package com.fortysevendeg.hood
+
+import arrow.core.Either
+import arrow.core.flatMap
+import arrow.core.toOption
+import arrow.data.extensions.list.foldable.nonEmpty
+import arrow.effects.IO
+import arrow.effects.extensions.io.fx.fx
+import arrow.effects.fix
+import arrow.effects.handleErrorWith
+import com.fortysevendeg.hood.github.GhInfo
+import com.fortysevendeg.hood.github.GithubCommentIntegration
+import com.fortysevendeg.hood.github.GithubCommon
+import com.fortysevendeg.hood.models.BadPerformanceBenchmarkError
+import com.fortysevendeg.hood.models.BenchmarkComparison
+import com.fortysevendeg.hood.models.BenchmarkComparisonError
+import java.io.File
+
+object HoodComparison {
+  fun compare(
+    previousBenchmarkPath: File,
+    currentBenchmarkPath: List<File>,
+    keyColumnName: String,
+    compareColumnName: String,
+    thresholdColumnName: String,
+    outputToFile: Boolean,
+    outputPath: String,
+    outputFormat: String,
+    generalThreshold: Double?,
+    benchmarkThreshold: Map<String, Double>?,
+    include: String?,
+    exclude: String?
+  ): IO<Unit> = fx {
+
+    val resultOrError = !Comparator.compareBenchmarks(
+      previousBenchmarkPath,
+      currentBenchmarkPath,
+      keyColumnName,
+      compareColumnName,
+      thresholdColumnName,
+      generalThreshold.toOption(),
+      benchmarkThreshold.toOption(),
+      include.toOption().map(String::toRegex),
+      exclude.toOption().map(String::toRegex)
+    )
+
+    println(resultOrError.prettyOutputResult())
+
+    val result = !resultOrError
+      .flatMap(List<BenchmarkComparison>::handleFailures)
+      .fromEither(BenchmarkComparisonError::error)
+
+    val allJson = JsonSupport.areAllJson(currentBenchmarkPath.plus(previousBenchmarkPath))
+
+    !OutputFile.sendOutputToFile(outputToFile, allJson, outputPath, result, outputFormat)
+
+  }
+
+  fun compareCI(
+    previousBenchmarkPath: File,
+    currentBenchmarkPath: List<File>,
+    keyColumnName: String,
+    compareColumnName: String,
+    thresholdColumnName: String,
+    outputToFile: Boolean,
+    outputPath: String,
+    outputFormat: String,
+    generalThreshold: Double?,
+    benchmarkThreshold: Map<String, Double>?,
+    include: String?,
+    exclude: String?,
+    info: GhInfo,
+    commitSha: String,
+    pr: Int
+  ): IO<Unit> = fx {
+
+    !GithubCommentIntegration.setPendingStatus(
+      info,
+      commitSha
+    )
+
+    val resultOrError: Either<BenchmarkComparisonError, List<BenchmarkComparison>> =
+      !Comparator.compareBenchmarks(
+        previousBenchmarkPath,
+        currentBenchmarkPath,
+        keyColumnName,
+        compareColumnName,
+        thresholdColumnName,
+        generalThreshold.toOption(),
+        benchmarkThreshold.toOption(),
+        include.toOption().map(String::toRegex),
+        exclude.toOption().map(String::toRegex)
+      )
+
+    val result = !resultOrError.getOrRaiseError(BenchmarkComparisonError::error)
+
+    val previousComment = !GithubCommentIntegration.getPreviousCommentId(info, pr)
+
+    val (commentResult) = previousComment.fold({
+      GithubCommentIntegration.createComment(info, pr, result)
+    }) { GithubCommentIntegration.updateComment(info, it, result) }
+
+    if (commentResult) !IO.unit
+    else !GithubCommon.raiseError("Error creating the comment")
+
+    val allJson = JsonSupport.areAllJson(currentBenchmarkPath.plus(previousBenchmarkPath))
+
+    !OutputFile.sendOutputToFile(outputToFile, allJson, outputPath, result, outputFormat)
+
+    val errors: List<BenchmarkComparison> = result.getWrongResults()
+
+    if (errors.nonEmpty()) {
+      !GithubCommentIntegration.setFailedStatus(
+        info,
+        commitSha,
+        errors.joinToString(transform = BenchmarkComparison::key)
+      ).flatMap { IO.raiseError<Unit>(BadPerformanceBenchmarkError(errors)) }
+    } else
+      !GithubCommentIntegration.setSuccessStatus(
+        info,
+        commitSha
+      )
+
+  }.fix().handleErrorWith {
+    GithubCommentIntegration.setFailedStatus(
+      info,
+      commitSha,
+      it.localizedMessage
+    )
+  }
+
+}

--- a/src/main/kotlin/com/fortysevendeg/hood/models/models.kt
+++ b/src/main/kotlin/com/fortysevendeg/hood/models/models.kt
@@ -47,9 +47,6 @@ sealed class BenchmarkResult {
 
 }
 
-object BenchmarkInconsistencyError :
-  Throwable("Benchmarks have different formats and cannot be compared")
-
 enum class GhStatusState(val value: String) {
   Succeed("success"), Pending("pending"), Failed("failure")
 }
@@ -90,6 +87,12 @@ data class BenchmarkComparison(
   val result: BenchmarkResult,
   val threshold: Double
 )
+
+object BenchmarkInconsistencyError :
+  Throwable("Benchmarks have different formats and cannot be compared")
+
+data class BadPerformanceBenchmarkError(val failures: List<BenchmarkComparison>) :
+  Throwable("Benchmarks shows a bad performance on the comparisons: ${failures.joinToString { it.key }}")
 
 data class BenchmarkComparisonError(val error: Throwable) {
   fun symbol(): String = "☠"

--- a/src/main/kotlin/com/fortysevendeg/hood/tasks/CompareBenchmark.kt
+++ b/src/main/kotlin/com/fortysevendeg/hood/tasks/CompareBenchmark.kt
@@ -1,6 +1,6 @@
 package com.fortysevendeg.hood.tasks
 
-import com.fortysevendeg.hood.*
+import com.fortysevendeg.hood.HoodComparison
 import org.gradle.api.DefaultTask
 import org.gradle.api.tasks.*
 import java.io.File

--- a/src/main/kotlin/com/fortysevendeg/hood/tasks/CompareBenchmark.kt
+++ b/src/main/kotlin/com/fortysevendeg/hood/tasks/CompareBenchmark.kt
@@ -1,12 +1,6 @@
 package com.fortysevendeg.hood.tasks
 
-import arrow.core.toOption
-import arrow.effects.extensions.io.applicativeError.fromEither
-import com.fortysevendeg.hood.Comparator
-import com.fortysevendeg.hood.JsonSupport
-import com.fortysevendeg.hood.OutputFile
-import com.fortysevendeg.hood.models.BenchmarkComparisonError
-import com.fortysevendeg.hood.prettyOutputResult
+import com.fortysevendeg.hood.*
 import org.gradle.api.DefaultTask
 import org.gradle.api.tasks.*
 import java.io.File
@@ -57,22 +51,19 @@ open class CompareBenchmark : DefaultTask() {
 
   @TaskAction
   fun compareBenchmark(): Unit =
-    Comparator.compareBenchmarks(
+    HoodComparison.compare(
       previousBenchmarkPath,
       currentBenchmarkPath,
       keyColumnName,
       compareColumnName,
       thresholdColumnName,
-      generalThreshold.toOption(),
-      benchmarkThreshold.toOption(),
-      include.toOption().map(String::toRegex),
-      exclude.toOption().map(String::toRegex)
-    ).flatMap {
-      println(it.prettyOutputResult())
-      it.fromEither(BenchmarkComparisonError::error)
-    }.flatMap {
-      val allJson = JsonSupport.areAllJson(currentBenchmarkPath.plus(previousBenchmarkPath))
-      OutputFile.sendOutputToFile(outputToFile, allJson, outputPath, it, outputFormat)
-    }.unsafeRunSync()
+      outputToFile,
+      outputPath,
+      outputFormat,
+      generalThreshold,
+      benchmarkThreshold,
+      include,
+      exclude
+    ).unsafeRunSync()
 
 }

--- a/src/main/kotlin/com/fortysevendeg/hood/tasks/CompareBenchmarkCI.kt
+++ b/src/main/kotlin/com/fortysevendeg/hood/tasks/CompareBenchmarkCI.kt
@@ -93,6 +93,12 @@ open class CompareBenchmarkCI : DefaultTask() {
         number
       )
     }.fix().getOrElse {
+
+      println(
+        """|Missing one of the following parameters: 'repositoryOwner', 'repositoryName', 'pullRequestSha', 'pullRequestNumber'.
+           |Comparison without CI features will be executed.""".trimMargin()
+      )
+
       HoodComparison.compare(
         previousBenchmarkPath,
         currentBenchmarkPath,

--- a/src/main/kotlin/com/fortysevendeg/hood/tasks/CompareBenchmarkCI.kt
+++ b/src/main/kotlin/com/fortysevendeg/hood/tasks/CompareBenchmarkCI.kt
@@ -1,12 +1,13 @@
 package com.fortysevendeg.hood.tasks
 
-import arrow.core.*
+import arrow.core.Option
 import arrow.core.extensions.option.applicative.applicative
-import arrow.effects.IO
+import arrow.core.fix
+import arrow.core.getOrElse
+import arrow.core.toOption
 import com.fortysevendeg.hood.HoodComparison
 import com.fortysevendeg.hood.github.GhInfo
 import org.gradle.api.DefaultTask
-import org.gradle.api.GradleException
 import org.gradle.api.tasks.*
 import java.io.File
 

--- a/src/main/kotlin/com/fortysevendeg/hood/tasks/CompareBenchmarkCI.kt
+++ b/src/main/kotlin/com/fortysevendeg/hood/tasks/CompareBenchmarkCI.kt
@@ -57,14 +57,19 @@ open class CompareBenchmarkCI : DefaultTask() {
 
   //CI
   @get:Input
+  @Optional
   var token: String? = project.objects.property(String::class.java).orNull
   @get:Input
+  @Optional
   var repositoryOwner: String? = project.objects.property(String::class.java).orNull
   @get:Input
+  @Optional
   var repositoryName: String? = project.objects.property(String::class.java).orNull
   @get:Input
+  @Optional
   var pullRequestSha: String? = project.objects.property(String::class.java).orNull
   @get:Input
+  @Optional
   var pullRequestNumber: Int? = project.objects.property(Int::class.java).orNull
 
   @TaskAction


### PR DESCRIPTION
Fixes #29
Now the comparison tasks should fail if the benchmark contains bad performances. Furthermore, the CI task will execute the regular one if one of the CI parameters is not available