### PR TITLE
Make CI task fail on error and allow status target

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,3 +18,4 @@ jobs:
     - stage: deploy
       script:
         - ./deploy-scripts/deploy.sh
+        - ./gradlew release

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,4 +18,3 @@ jobs:
     - stage: deploy
       script:
         - ./deploy-scripts/deploy.sh
-        - ./gradlew release

--- a/README.md
+++ b/README.md
@@ -29,8 +29,11 @@ The `compareBenchmarksCI` task also needs some extra parameters:
  - **repositoryName**: The repository name.
  - **pullRequestSha**: The sha for the Pull Request. The environment variable `TRAVIS_PULL_REQUEST_SHA` on Travis CI.
  - **pullRequestNumber**: The number of the Pull Request. The environment variable `TRAVIS_PULL_REQUEST` on Travis CI.
+ - **statusTargetUrl**: The URL to the CI job. The environment variable `TRAVIS_JOB_WEB_URL` on Travis CI. Optional.
 
-***Note***: Currently **Hood** only supports `CSV` and `JSON` based benchmarks with cross comparison available.
+***Note***: Currently **Hood** only supports `CSV` and `JSON` based benchmarks with cross comparison available. 
+***Note 2***: If the `CI` integration is not available because one the requested fields above is not defined, 
+  the task `compareBenchmarksCI` will be executed on the same way as `compareBenchmarks`.
 
 ### Send output to a file
 

--- a/build.gradle
+++ b/build.gradle
@@ -103,3 +103,5 @@ release {
   tagCommitMessage = "Publish "
   newVersionCommitMessage = "Setting version to"
 }
+
+afterReleaseBuild.dependsOn bintrayUpload

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ buildscript {
   ext {
     kotlinVersion = "1.3.40"
     arrowVersion = "0.9.0"
+    gradleReleaseVersion = '2.6.0'
     http4kVersion = "3.160.1"
     kotlintestVersion = "3.3.3"
     bintrayVersion = "1.8.4"
@@ -17,6 +18,7 @@ buildscript {
   dependencies {
     classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
     classpath "com.jfrog.bintray.gradle:gradle-bintray-plugin:$bintrayVersion"
+    classpath "net.researchgate:gradle-release:$gradleReleaseVersion"
   }
 }
 
@@ -93,3 +95,10 @@ bintray {
   }
 }
 
+release {
+  scmAdapters = [ net.researchgate.release.GitAdapter ]
+  preCommitText = "[ci skip] - "
+  preTagCommitMessage = "Publish "
+  tagCommitMessage = "Publish "
+  newVersionCommitMessage = "Setting version to"
+}

--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ apply plugin: "kotlin"
 apply plugin: "java-gradle-plugin"
 apply plugin: "com.jfrog.bintray"
 apply plugin: "maven-publish"
+apply plugin: "gradle-release"
 
 repositories {
   maven { url "https://dl.bintray.com/arrow-kt/arrow-kt/" }

--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ apply plugin: "kotlin"
 apply plugin: "java-gradle-plugin"
 apply plugin: "com.jfrog.bintray"
 apply plugin: "maven-publish"
-apply plugin: "gradle-release"
+apply plugin: "net.researchgate.release"
 
 repositories {
   maven { url "https://dl.bintray.com/arrow-kt/arrow-kt/" }

--- a/deploy-scripts/deploy_release.sh
+++ b/deploy-scripts/deploy_release.sh
@@ -16,6 +16,6 @@ elif [ "$TRAVIS_BRANCH" != "$BRANCH" ]; then
 elif ! [[ "$VERSION_NAME" =~ $VERSION_PATTERN ]]; then
   fail "Failed release deployment: wrong version. Expected '$VERSION_NAME' to have pattern 'X.Y.Z'"
 else
-  ./gradlew bintrayUpload
+  ./gradlew bintrayUpload release
   echo "Release '$VERSION_NAME' deployed!"
 fi

--- a/deploy-scripts/deploy_release.sh
+++ b/deploy-scripts/deploy_release.sh
@@ -16,6 +16,6 @@ elif [ "$TRAVIS_BRANCH" != "$BRANCH" ]; then
 elif ! [[ "$VERSION_NAME" =~ $VERSION_PATTERN ]]; then
   fail "Failed release deployment: wrong version. Expected '$VERSION_NAME' to have pattern 'X.Y.Z'"
 else
-  ./gradlew bintrayUpload release
+  ./gradlew release
   echo "Release '$VERSION_NAME' deployed!"
 fi

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,10 +1,10 @@
 # Package definitions
 group=com.47deg
-version=0.6.2-SNAPSHOT
+version=0.7.0
 
 #Release
 release.useAutomaticVersion=true
-release.newVersion=0.6.3-SNAPSHOT
+release.newVersion=0.7.1-SNAPSHOT
 
 # Gradle options
 org.gradle.warning.mode=all

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ version=0.6.2-SNAPSHOT
 
 #Release
 release.useAutomaticVersion=true
-release.newVersion=0.6.2-SNAPSHOT
+release.newVersion=0.6.3-SNAPSHOT
 
 # Gradle options
 org.gradle.warning.mode=all

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 # Package definitions
-GROUP=com.47deg
-VERSION_NAME=0.6.1
+group=com.47deg
+version=0.6.1
 # Gradle options
 org.gradle.warning.mode=all
 #Settings

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,11 @@
 # Package definitions
 group=com.47deg
-version=0.6.1
+version=0.6.2-SNAPSHOT
+
+#Release
+release.useAutomaticVersion=true
+release.newVersion=0.6.2-SNAPSHOT
+
 # Gradle options
 org.gradle.warning.mode=all
 #Settings

--- a/gradle/gradle-mvn-push.gradle
+++ b/gradle/gradle-mvn-push.gradle
@@ -1,5 +1,3 @@
-version = VERSION_NAME
-group = GROUP
 
 def getReleaseRepositoryUrl() {
   return findProperty("RELEASE_REPOSITORY_URL") ?: "https://api.bintray.com/maven/47deg/hood/hood"

--- a/src/main/kotlin/com/fortysevendeg/hood/HoodComparison.kt
+++ b/src/main/kotlin/com/fortysevendeg/hood/HoodComparison.kt
@@ -132,7 +132,10 @@ object HoodComparison {
       commitSha,
       ex.localizedMessage,
       statusTargetUrl
-    ).flatMap { IO.raiseError<Unit>(ex) }
+    ).flatMap {
+      @Suppress("RemoveExplicitTypeArguments")
+      IO.raiseError<Unit>(ex)
+    }
   }
 
 }

--- a/src/main/kotlin/com/fortysevendeg/hood/HoodComparison.kt
+++ b/src/main/kotlin/com/fortysevendeg/hood/HoodComparison.kt
@@ -15,6 +15,7 @@ import com.fortysevendeg.hood.models.BadPerformanceBenchmarkError
 import com.fortysevendeg.hood.models.BenchmarkComparison
 import com.fortysevendeg.hood.models.BenchmarkComparisonError
 import java.io.File
+import java.net.URI
 
 object HoodComparison {
   fun compare(
@@ -71,12 +72,14 @@ object HoodComparison {
     exclude: String?,
     info: GhInfo,
     commitSha: String,
-    pr: Int
+    pr: Int,
+    statusTargetUrl: URI?
   ): IO<Unit> = fx {
 
     !GithubCommentIntegration.setPendingStatus(
       info,
-      commitSha
+      commitSha,
+      statusTargetUrl
     )
 
     val resultOrError: Either<BenchmarkComparisonError, List<BenchmarkComparison>> =
@@ -113,20 +116,23 @@ object HoodComparison {
       !GithubCommentIntegration.setFailedStatus(
         info,
         commitSha,
-        errors.joinToString(transform = BenchmarkComparison::key)
+        errors.joinToString(transform = BenchmarkComparison::key),
+        statusTargetUrl
       ).flatMap { IO.raiseError<Unit>(BadPerformanceBenchmarkError(errors)) }
     } else
       !GithubCommentIntegration.setSuccessStatus(
         info,
-        commitSha
+        commitSha,
+        statusTargetUrl
       )
 
-  }.fix().handleErrorWith {
+  }.fix().handleErrorWith { ex ->
     GithubCommentIntegration.setFailedStatus(
       info,
       commitSha,
-      it.localizedMessage
-    )
+      ex.localizedMessage,
+      statusTargetUrl
+    ).flatMap { IO.raiseError(ex) }
   }
 
 }

--- a/src/main/kotlin/com/fortysevendeg/hood/HoodComparison.kt
+++ b/src/main/kotlin/com/fortysevendeg/hood/HoodComparison.kt
@@ -132,7 +132,7 @@ object HoodComparison {
       commitSha,
       ex.localizedMessage,
       statusTargetUrl
-    ).flatMap { IO.raiseError(ex) }
+    ).flatMap { IO.raiseError<Unit>(ex) }
   }
 
 }

--- a/src/main/kotlin/com/fortysevendeg/hood/github/GithubCommentIntegration.kt
+++ b/src/main/kotlin/com/fortysevendeg/hood/github/GithubCommentIntegration.kt
@@ -17,6 +17,7 @@ import org.http4k.core.Status
 import org.http4k.core.with
 import org.http4k.format.Jackson
 import org.http4k.format.Jackson.json
+import java.net.URI
 
 object GithubCommentIntegration {
 
@@ -71,6 +72,7 @@ object GithubCommentIntegration {
     val body = Jackson {
       obj(
         "state" to string(status.state.value),
+        "target_url" to string(status.targetUrl.toString()),
         "description" to string(status.description),
         "context" to string(status.context)
       )
@@ -91,27 +93,36 @@ object GithubCommentIntegration {
     }
   }
 
-  fun setPendingStatus(info: GhInfo, commitSha: String): IO<Unit> = setStatus(
-    info, commitSha,
-    GhStatus(
-      GhStatusState.Pending,
-      "Comparing Benchmarks"
+  fun setPendingStatus(info: GhInfo, commitSha: String, targetUrl: URI?): IO<Unit> =
+    setStatus(
+      info, commitSha,
+      GhStatus(
+        GhStatusState.Pending,
+        targetUrl,
+        "Comparing Benchmarks"
+      )
     )
-  )
 
-  fun setSuccessStatus(info: GhInfo, commitSha: String): IO<Unit> = setStatus(
-    info, commitSha,
-    GhStatus(
-      GhStatusState.Succeed,
-      "Benchmarks comparison passed"
+  fun setSuccessStatus(info: GhInfo, commitSha: String, targetUrl: URI?): IO<Unit> =
+    setStatus(
+      info, commitSha,
+      GhStatus(
+        GhStatusState.Succeed,
+        targetUrl,
+        "Benchmarks comparison passed"
+      )
     )
-  )
 
-  fun setFailedStatus(info: GhInfo, commitSha: String, comment: String): IO<Unit> =
+  fun setFailedStatus(
+    info: GhInfo,
+    commitSha: String,
+    comment: String,
+    targetUrl: URI?
+  ): IO<Unit> =
     setStatus(
       info,
       commitSha,
-      GhStatus(GhStatusState.Failed, "Benchmarks comparison failed: $comment")
+      GhStatus(GhStatusState.Failed, targetUrl, "Benchmarks comparison failed: $comment")
     )
 
 }

--- a/src/main/kotlin/com/fortysevendeg/hood/github/models.kt
+++ b/src/main/kotlin/com/fortysevendeg/hood/github/models.kt
@@ -1,11 +1,13 @@
 package com.fortysevendeg.hood.github
 
 import com.fortysevendeg.hood.models.GhStatusState
+import java.net.URI
 
 data class GhInfo(val owner: String, val repo: String, val token: String)
 
 data class GhStatus(
   val state: GhStatusState,
+  val targetUrl: URI?,
   val description: String,
   val context: String = "benchmark-ci/hood"
 )

--- a/src/main/kotlin/com/fortysevendeg/hood/tasks/CompareBenchmarkCI.kt
+++ b/src/main/kotlin/com/fortysevendeg/hood/tasks/CompareBenchmarkCI.kt
@@ -10,6 +10,7 @@ import com.fortysevendeg.hood.github.GhInfo
 import org.gradle.api.DefaultTask
 import org.gradle.api.tasks.*
 import java.io.File
+import java.net.URI
 
 open class CompareBenchmarkCI : DefaultTask() {
 
@@ -71,6 +72,9 @@ open class CompareBenchmarkCI : DefaultTask() {
   @get:Input
   @Optional
   var pullRequestNumber: Int? = project.objects.property(Int::class.java).orNull
+  @get:Input
+  @Optional
+  var statusTargetUrl: URI? = project.objects.property(URI::class.java).orNull
 
   @TaskAction
   fun compareBenchmarkCI() =
@@ -96,7 +100,8 @@ open class CompareBenchmarkCI : DefaultTask() {
         exclude,
         GhInfo(owner, name, token),
         sha,
-        number
+        number,
+        statusTargetUrl
       )
     }.fix().getOrElse {
 


### PR DESCRIPTION
This PR contains some improvements and fixes: 
- Make the CI task fail on errors as the regular one.
 - Add an extra parameter to set the target URL on the Github status.
 - Add the release plugin to handle versioning and tag creation

Release 0.7.0
