### PR TITLE
Set code snippets with codetab web component

### DIFF
--- a/docs/_includes/_head.html
+++ b/docs/_includes/_head.html
@@ -23,6 +23,10 @@
 
   <!-- Font-awesome -->
   <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.css" Content-Type="text/css" crossorigin="anonymous" rel="stylesheet">
+
+  <script type="module" src="https://unpkg.com/@47deg/codetab/dist/codetab/codetab.esm.js"></script>
+  <script nomodule defer src="https://unpkg.com/@47deg/codetab/dist/codetab/codetab.js"></script>
+
   <script src="{{ '/js/highlight.pack.js' | relative_url }}"></script>
   <script>
     hljs.initHighlightingOnLoad();

--- a/docs/docs/CI/README.md
+++ b/docs/docs/CI/README.md
@@ -49,7 +49,6 @@ The task can send the result to a file with the following parameters:
 
 <fortyseven-codetab data-languages='["Groovy", "Kotlin"]' markdown="block">
 ```groovy
-//Groovy
 compareBenchmarksCI {
   previousBenchmarkPath = file("$rootDir/hood_master/build/reports/master_benchmark.json")
   currentBenchmarkPath = [file("$rootDir/build/reports/hood_benchmark.json")]
@@ -66,7 +65,6 @@ compareBenchmarksCI {
 ```
 
 ```kotlin
-//Kotlin
 tasks.compareBenchmarksCI {
   previousBenchmarkPath = file("$rootDir/hood_master/build/reports/master_benchmark.json")
   currentBenchmarkPath = listOf(file("$rootDir/build/reports/hood_benchmark.json"))

--- a/docs/docs/CI/README.md
+++ b/docs/docs/CI/README.md
@@ -47,6 +47,7 @@ The task can send the result to a file with the following parameters:
 
 ## Configuration example
 
+<fortyseven-codetab data-languages='["Groovy", "Kotlin"]' markdown="block">
 ```groovy
 //Groovy
 compareBenchmarksCI {
@@ -81,3 +82,4 @@ tasks.compareBenchmarksCI {
   statusTargetUrl = (System.getenv("TRAVIS_JOB_WEB_URL") ?: URI.create(System.getenv("TRAVIS_JOB_WEB_URL"))) as URI?
 }
 ```
+</fortyseven-codetab>

--- a/docs/docs/README.md
+++ b/docs/docs/README.md
@@ -24,14 +24,12 @@ To add the Hood plugin dependency on Gradle, you can use:
 
 <fortyseven-codetab data-languages='["Groovy", "Kotlin"]' markdown="block">
 ```groovy
-//Groovy
 plugins {
   id "com.47deg.hood" version "0.8.0"
 }
 ```
 
 ```kotlin
-//Kotlin
 plugins {
   id("com.47deg.hood") version "0.8.0"
 }
@@ -42,7 +40,6 @@ Don't forget to add the `pluginManagement` block at the top of your `settings.gr
 
 <fortyseven-codetab data-languages='["Groovy", "Kotlin"]' markdown="block">
 ```groovy
-//Groovy
 pluginManagement {
   repositories {
     maven { url "https://dl.bintray.com/47deg/hood" }
@@ -52,7 +49,6 @@ pluginManagement {
 ```
 
 ```kotlin
-//Kotlin
 pluginManagement {
   repositories {
     maven("https://dl.bintray.com/47deg/hood")
@@ -68,7 +64,6 @@ To use plugin through imperative syntax, you need to first add the dependency on
 
 <fortyseven-codetab data-languages='["Groovy", "Kotlin"]' markdown="block">
 ```groovy
-//Groovy
 buildscript {
   repositories {
     maven { url "https://dl.bintray.com/47deg/hood" }
@@ -81,7 +76,6 @@ buildscript {
 ```
 
 ```kotlin
-//Kotlin
 buildscript {
   repositories {
     maven("https://dl.bintray.com/47deg/hood")
@@ -98,12 +92,10 @@ and then you will be able to add it with `apply`:
 
 <fortyseven-codetab data-languages='["Groovy", "Kotlin"]' markdown="block">
 ```groovy
-//Groovy
 apply plugin: "com.47deg.hood"
 ```
 
 ```kotlin
-//Kotlin
 apply(plugin = "com.47deg.hood")
 ```
 </fortyseven-codetab>

--- a/docs/docs/README.md
+++ b/docs/docs/README.md
@@ -22,6 +22,7 @@ To add the Hood plugin dependency on Gradle, you can use:
 
 #### Declarative syntax (especially recommended for the Kotlin DSL)
 
+<fortyseven-codetab data-languages='["Groovy", "Kotlin"]' markdown="block">
 ```groovy
 //Groovy
 plugins {
@@ -35,9 +36,11 @@ plugins {
   id("com.47deg.hood") version "0.8.0"
 }
 ```
+</fortyseven-codetab>
 
 Don't forget to add the `pluginManagement` block at the top of your `settings.gradle/.kts` if you are not able to find it:
 
+<fortyseven-codetab data-languages='["Groovy", "Kotlin"]' markdown="block">
 ```groovy
 //Groovy
 pluginManagement {
@@ -57,11 +60,13 @@ pluginManagement {
   }
 }
 ```
+</fortyseven-codetab>
 
 #### Imperative syntax
 
 To use plugin through imperative syntax, you need to first add the dependency on the `buildscript`:
 
+<fortyseven-codetab data-languages='["Groovy", "Kotlin"]' markdown="block">
 ```groovy
 //Groovy
 buildscript {
@@ -87,9 +92,11 @@ buildscript {
   }
 }
 ```
+</fortyseven-codetab>
 
 and then you will be able to add it with `apply`:
 
+<fortyseven-codetab data-languages='["Groovy", "Kotlin"]' markdown="block">
 ```groovy
 //Groovy
 apply plugin: "com.47deg.hood"
@@ -99,6 +106,7 @@ apply plugin: "com.47deg.hood"
 //Kotlin
 apply(plugin = "com.47deg.hood")
 ```
+</fortyseven-codetab>
 
 ## The visualizer companion
 

--- a/docs/docs/benchmarks/README.md
+++ b/docs/docs/benchmarks/README.md
@@ -37,6 +37,7 @@ The task can send the result to a file with the following parameters:
 
 ## Configuration example
 
+<fortyseven-codetab data-languages='["Groovy", "Kotlin"]' markdown="block">
 ```groovy
 //Groovy
 compareBenchmarks {
@@ -56,3 +57,4 @@ tasks.compareBenchmarks {
   benchmarkThreshold = mapOf("Parsing" to 500.00)
 }
 ```
+</fortyseven-codetab>

--- a/docs/docs/benchmarks/README.md
+++ b/docs/docs/benchmarks/README.md
@@ -39,7 +39,6 @@ The task can send the result to a file with the following parameters:
 
 <fortyseven-codetab data-languages='["Groovy", "Kotlin"]' markdown="block">
 ```groovy
-//Groovy
 compareBenchmarks {
   previousBenchmarkPath = file("$rootDir/benchmarks/master_benchmark.json")
   currentBenchmarkPath = [file("$rootDir/build/reports/hood_benchmark.json")]
@@ -49,7 +48,6 @@ compareBenchmarks {
 ```
 
 ```kotlin
-//Kotlin
 tasks.compareBenchmarks {
   previousBenchmarkPath = file("$rootDir/benchmarks/master_benchmark.json")
   currentBenchmarkPath = listOf(file("$rootDir/build/reports/hood_benchmark.json"))

--- a/docs/docs/upload/README.md
+++ b/docs/docs/upload/README.md
@@ -21,6 +21,7 @@ The task `uploadBenchmarks` has the following parameters:
 
 ## Configuration example
 
+<fortyseven-codetab data-languages='["Groovy", "Kotlin"]' markdown="block">
  ```groovy
 //Groovy
 uploadBenchmarks {
@@ -42,3 +43,4 @@ tasks.uploadBenchmarks {
   commitMessage = "[ci skip] - Upload benchmark"
 }
 ```
+</fortyseven-codetab>

--- a/docs/docs/upload/README.md
+++ b/docs/docs/upload/README.md
@@ -23,7 +23,6 @@ The task `uploadBenchmarks` has the following parameters:
 
 <fortyseven-codetab data-languages='["Groovy", "Kotlin"]' markdown="block">
  ```groovy
-//Groovy
 uploadBenchmarks {
   benchmarkFiles = [file("$rootDir/build/reports/master_benchmark.json"), file("$rootDir/build/reports/libraries_benchmark.json")]
   token = System.getenv("GITHUB_ACCESS_TOKEN")
@@ -34,7 +33,6 @@ uploadBenchmarks {
 ```
 
 ```kotlin
-//Kotlin
 tasks.uploadBenchmarks {
   benchmarkFiles = listOf(file("$rootDir/build/reports/master_benchmark.json"), file("$rootDir/build/reports/libraries_benchmark.json"))
   token = System.getenv("GITHUB_ACCESS_TOKEN")


### PR DESCRIPTION
* Add codetab load script to docs layout.
* Wrap doc code snippets with codetab web component.

![image](https://user-images.githubusercontent.com/7753447/76641335-bc0dd180-6551-11ea-8fbf-052538ce513f.png)
